### PR TITLE
JSON-LD Antwoorden voor de REST API

### DIFF
--- a/imbor_rest/__init__.py
+++ b/imbor_rest/__init__.py
@@ -1,4 +1,5 @@
 from .imbor_rest import *
+from .views import sparql
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 

--- a/imbor_rest/crow_ldp_caller.py
+++ b/imbor_rest/crow_ldp_caller.py
@@ -63,7 +63,7 @@ class CrowLdp:
     def run_query(self, payload):
         s = Session()
         url = self.base_url
-        querystring = {"output": "json", "toolid": self.toolId, "trace": "namespaces"}
+        querystring = {"toolid": self.toolId, "trace": "namespaces"}
         url = str(url) + "?" + urllib.parse.urlencode(querystring)
 
         req = Request("POST", url, data=payload)
@@ -71,7 +71,11 @@ class CrowLdp:
         req.headers = headers
         auth = self.get_hmac(req, url)
         # print(auth)
-        headers = {"Authorization": auth, "Content-Type": "application/sparql-query"}
+        headers = {
+            "Authorization": auth,
+            "Content-Type": "application/sparql-query",
+            "Accept": "application/ld+json, text/turtle, */*",
+        }
         req.headers = headers
         prepared = req.prepare()
         response = s.send(prepared)

--- a/imbor_rest/crow_ldp_caller.py
+++ b/imbor_rest/crow_ldp_caller.py
@@ -14,13 +14,9 @@ class CrowLdp:
         self.privateKey = privateKey
         self.base_url = base_url
 
-        # print("clientId: " + str(self.clientId))
-        # print("toolId: " + str(self.toolId))
-        # print("privateKey: " + str(self.privateKey))
-        # print("base_url: " + str(self.base_url))
-
-    # Functie om de HMAC signature te berekenen, zie documentatie van CROW voor de benodigde parameters
     def get_hmac(self, req, url):
+        """Calculates HMAC signature"""
+        # Functie om de HMAC signature te berekenen, zie documentatie van CROW voor de benodigde parameters
         # Timestamp (op secondes, afgesloten met een 'Z')
         currentDate = datetime.datetime.now().replace(microsecond=0).isoformat() + "Z"
         # Random GUID conform RFC 4122
@@ -59,11 +55,64 @@ class CrowLdp:
 
         return authorization
 
+    def rest(self, *, payload=""):
+        """Send any request to LDP"""
+        return ""
+
+    def _sparql_query(self, *, query, output, accept, method):
+        """Internal method to send a SPARQL query"""
+        s = Session()
+        url = self.base_url
+        querystring = {"toolid": self.toolId, "trace": "namespaces"}
+        if output is not None:
+            querystring["output"] = output
+
+        url = str(url) + "?" + urllib.parse.urlencode(querystring)
+
+        req = Request(method, url, data=query)
+        headers = {"Content-Type": "application/sparql-query"}
+        req.headers = headers
+        auth = self.get_hmac(req, url)
+        # print(auth)
+        headers = {
+            "Authorization": auth,
+            "Content-Type": "application/sparql-query",
+        }
+        if accept is not None:
+            headers["Accept"] = accept
+
+        req.headers = headers
+        prepared = req.prepare()
+        response = s.send(prepared)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(
+                "Query failed to run by returning code of {}. {}".format(
+                    response.status_code, response.text
+                )
+            )
+
+    def select(self, *, query):
+        """Send SELECT query (JSON SPARQL response)."""
+        return self._sparql_query(
+            query=query, output="json", accept=None, method="POST"
+        )
+
+    def construct(self, *, query):
+        """Send CONSTRUCT query (JSON-LD response)."""
+        return self._sparql_query(
+            query=query,
+            output=None,
+            accept="application/ld+json, text/turtle, */*",
+            method="POST",
+        )
+
     # helper functie om het request te doen
     def run_query(self, payload):
         s = Session()
         url = self.base_url
-        querystring = {"toolid": self.toolId, "trace": "namespaces"}
+        querystring = {"toolid": self.toolId, "trace": "namespaces", "output": "json"}
         url = str(url) + "?" + urllib.parse.urlencode(querystring)
 
         req = Request("POST", url, data=payload)
@@ -74,7 +123,7 @@ class CrowLdp:
         headers = {
             "Authorization": auth,
             "Content-Type": "application/sparql-query",
-            "Accept": "application/ld+json, text/turtle, */*",
+            # "Accept": "application/ld+json, text/turtle, */*",
         }
         req.headers = headers
         prepared = req.prepare()

--- a/imbor_rest/imbor_rest.py
+++ b/imbor_rest/imbor_rest.py
@@ -24,6 +24,41 @@ crow_ldp = CrowLdp(
 
 otl_queries = OtlQueries()
 
+
+class CONTEXTS:
+    Beheerobject = {
+        "@language": "nl-nl",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "subClassOf": {
+            "@id": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "@type": "@id",
+        },
+        "guid": {
+            "@id": "http://www.w3.org/2004/02/skos/core#notation",
+            "@type": "@id",
+        },
+        "definition": "http://www.w3.org/2004/02/skos/core#definition",
+    }
+
+
+def swagger_property_schema_for_jsonld_context(context):
+    schema = dict()
+
+    for k, v in context.items():
+        if isinstance(v, dict):
+            if v["@type"] == "@id":
+                schema[k] = {"type": "string", "format": "uri"}
+                continue
+
+        if "@" in k:
+            continue
+
+        schema[k] = {"type": "string"}
+
+    return schema
+
+
 swagger = Swagger(
     app,
     template={
@@ -54,11 +89,9 @@ swagger = Swagger(
                     }
                 },
                 "beheerobjecten": {
-                    "properties": {
-                        "FysiekObjectURI": {"type": "string", "format": "uri"},
-                        "FysiekObjectLabel": {"type": "string"},
-                        "FysiekObjectDefinitie": {"type": "string"},
-                    }
+                    "properties": swagger_property_schema_for_jsonld_context(
+                        CONTEXTS.Beheerobject
+                    )
                 },
                 "beheerobject_eigenschappen": {
                     "properties": {
@@ -204,25 +237,10 @@ def get_beheerobjecten():
 
     # limit en paging
 
-    context = {
-        "@language": "nl-nl",
-        "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "subClassOf": {
-            "@id": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
-            "@type": "@id",
-        },
-        "guid": {
-            "@id": "http://www.w3.org/2004/02/skos/core#notation",
-            "@type": "@id",
-        },
-        "definition": "http://www.w3.org/2004/02/skos/core#definition",
-    }
-
     response = list()
 
     for beheerobject in res:
-        response.append(jsonld.compact(beheerobject, context))
+        response.append(jsonld.compact(beheerobject, CONTEXTS.Beheerobject))
 
     # print(type(res))
 

--- a/imbor_rest/imbor_rest.py
+++ b/imbor_rest/imbor_rest.py
@@ -4,6 +4,8 @@ from flask_talisman import Talisman
 from .crow_ldp_caller import CrowLdp
 from .queries import OtlQueries
 from flask_cors import CORS
+from pyld import jsonld
+import json
 
 app = Flask(__name__)
 # let op, hier verwijzen naar de juiste config file met api keys
@@ -200,7 +202,35 @@ def get_beheerobjecten():
 
     res = crow_ldp.run_query(otl_queries.selecteer_beheerobjecten())
 
-    return res, 200
+    # limit en paging
+
+    context = {
+        "@language": "nl-nl",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "subClassOf": {
+            "@id": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "@type": "@id",
+        },
+        "guid": {
+            "@id": "http://www.w3.org/2004/02/skos/core#notation",
+            "@type": "@id",
+        },
+        "definition": "http://www.w3.org/2004/02/skos/core#definition",
+    }
+
+    response = list()
+
+    for beheerobject in res:
+        response.append(jsonld.compact(beheerobject, context))
+
+    # print(type(res))
+
+    return (
+        json.dumps(response, ensure_ascii=False),
+        200,
+        {"Content-Type": "application/ld+json"},
+    )
 
 
 @app.route("/beheerobjecten/<string:beheerobject>/")
@@ -233,4 +263,3 @@ def get_eigenschappen_per_beheerobject(beheerobject):
     )
 
     return res, 200
-

--- a/imbor_rest/imbor_rest.py
+++ b/imbor_rest/imbor_rest.py
@@ -233,7 +233,7 @@ def get_beheerobjecten():
 
     """
 
-    res = crow_ldp.run_query(otl_queries.selecteer_beheerobjecten())
+    res = crow_ldp.construct(query=otl_queries.selecteer_beheerobjecten())
 
     # limit en paging
 

--- a/imbor_rest/queries.py
+++ b/imbor_rest/queries.py
@@ -81,18 +81,7 @@ class OtlQueries:
             + """
                 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
                 
-                SELECT (?thing AS ?FysiekObjectURI) ?FysiekObjectLabel ?FysiekObjectDefinitie 
-                WHERE {
-                # Selecteer alleen klassen ...
-                    ?thing a rdfs:Class ; 
-                # ... die een directe subklasse zijn van NTA8035 Fysiek object ...
-                           rdfs:subClassOf nta8035:PhysicalObject ; 
-                # ... en een preferred label hebben ...
-                           skos:prefLabel ?FysiekObjectLabel ; 
-                # ... en een definitie hebben.
-                           skos:definition ?FysiekObjectDefinitie .
-                }
-                ORDER BY ?FysiekObjectLabel
+                CONSTRUCT { ?s ?p ?o } WHERE { ?s rdfs:subClassOf nta8035:PhysicalObject ; ?p ?o . } 
            """
         )
 
@@ -140,5 +129,5 @@ class OtlQueries:
                 }
                 
                 ORDER BY str(?FysiekObjectLabel) str(?EigenschapLabel) str(?EigenschapVanObjectLabel)
-           """        )
-
+           """
+        )

--- a/imbor_rest/templates/yasgui.html
+++ b/imbor_rest/templates/yasgui.html
@@ -1,0 +1,80 @@
+<head>
+    <link href="https://unpkg.com/@triply/yasgui/build/yasgui.min.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/@triply/yasgui/build/yasgui.min.js"></script>
+    <style>
+        .yasgui .autocompleteWrapper {
+            /* display: none !important ; */
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+            margin: 0;
+        }
+
+        header {
+            background-color: #009de0;
+            color: white;
+            padding: 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        header * {
+            margin: 0;
+            color: white;
+        }
+
+        main {
+            margin: 1rem ;
+        }
+    </style>
+</head>
+
+<body>
+    <header>
+        <h1>CROW REST API</h1>
+        <p>Zoekvragen vereisen een toepasselijk abonnement op <a href='http://crow.nl'>CROW.nl</a>.</p>
+    </header>
+    <main>
+        <div id="yasgui"></div>
+    </main>
+    <script>
+        const yasgui = new Yasgui(document.getElementById("yasgui"), {
+            requestConfig: {
+                endpoint: "{{ base_url }}endpoint/sparql",
+                method: "POST",
+            },
+            copyEndpointOnNewTab: true,
+            endpointCatalogueOptions: {
+                getData: () => {
+                    return [
+                        //List of objects should contain the endpoint field
+                        //Feel free to include any other fields (e.g. a description or icon
+                        //that you'd like to use when rendering)
+                        {
+                            endpoint: "{{ base_url }}endpoint/sparql",
+                            method: "POST",
+                        },
+                        {
+                            endpoint: "https://dbpedia.org/sparql"
+                        },
+                        {
+                            endpoint: "https://query.wikidata.org"
+                        },
+                    ];
+                },
+                //Data object keys that are used for filtering. The 'endpoint' key already used by default
+                keys: [],
+                //Data argument contains a `value` property for the matched data object
+                //Source argument is the suggestion DOM element to append your rendered item to
+                renderItem: (data, source) => {
+                    const contentDiv = document.createElement("div");
+                    contentDiv.innerText = data.value.endpoint;
+                    source.appendChild(contentDiv);
+                }
+            }
+
+        });
+    </script>
+</body>

--- a/imbor_rest/views/sparql.py
+++ b/imbor_rest/views/sparql.py
@@ -1,0 +1,25 @@
+from ..imbor_rest import app, crow_ldp
+from flask import render_template, request
+
+
+@app.route("/endpoint/sparql", methods=["POST"])
+def sparql():
+    """
+    Programmatically query with SPARQL (without hmac).
+    """
+    # TODO: Ondersteun meer dan alleen POST / SELECT
+    # TODO: Voor het uploaden van datasets, ondersteun meer dan 1 MB
+
+    if request.content_length > 1024 * 1024:  # 1 MB
+        return "Payload too large (> 1MB)", 413
+
+    res = crow_ldp.select(query=request.form["query"])
+    return res, 200
+
+
+@app.route("/query")
+def yasgui():
+    """
+    Visually query with SPARQL (without hmac).
+    """
+    return render_template("yasgui.html", base_url=request.url_root)


### PR DESCRIPTION
In deze branch worden niet meer `SELECT` query's gebruikt, maar worden er met `CONSTRUCT` query's JSON-LD responses klaargezet.

JSON-LD is volgens mij duidelijker voor programmeurs dan het [SPARQL Query Results JSON Format][1]. 

[1]: https://www.w3.org/TR/sparql11-results-json/

```json
[
  {
    "@context": {
      "@language": "nl-nl",
      "label": "http://www.w3.org/2000/01/rdf-schema#label",
      "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
      "subClassOf": {
        "@id": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
        "@type": "@id"
      },
      "guid": {
        "@id": "http://www.w3.org/2004/02/skos/core#notation",
        "@type": "@id"
      },
      "definition": "http://www.w3.org/2004/02/skos/core#definition"
    },
    "@id": "http://linkeddata.crow.nl/.../def/objecttype/OBB1007",
    "@type": "http://www.w3.org/2000/01/rdf-schema#Class",
    "label": "Verkeersintensiteit",
    "subClassOf": "https://w3id.org/def/basicsemantics-owl#PhysicalObject",
    "definition": "Hulpobject om de verkeersintensiteit ...",
    "guid": "urn:uuid:3024D1EB-9052-46C0-A051-8156A01CEF72",
    "prefLabel": "Verkeersintensiteit"
  }, { ... }
]
```